### PR TITLE
#1 Fix a problem where plasma effect did not stop.

### DIFF
--- a/Notchmeister/Notchmeister/PlasmaEffect.swift
+++ b/Notchmeister/Notchmeister/PlasmaEffect.swift
@@ -104,7 +104,8 @@ class PlasmaEffect: NotchEffect {
 	}
 	
 	override func mouseExited(at point: CGPoint, underNotch: Bool) {
-		plasmaLayer.emitterCells?.first?.birthRate = 0
+        plasmaLayer.emitterCells?.first?.birthRate = 0
+        plasmaLayer.emitterPosition = point
 	}
 
 }


### PR DESCRIPTION
Sometimes the plasma effect will not stop rendering when the mouse is moved outside the notched area. Having a second display arranged above the notched laptop screen so that the cursor can exit the notch from the top side seems to be a (or the only) way to produce the problem.

Debugging indicates that even though the expected `mouseExited(at:underNotch:)` method is called on `PlasmaEffect`, setting the `emitterCell.birthRate` to zero is not sufficient to stop the cell from rendering. Making sure to also update the `plasmaLayer.emitterPosition` value seems to be enough to get the birth rate change to take hold. This indicates that there is something unexpected happening in the emitterCell / Layer, which makes me think I'm just overlooking something. This does seem to work though and seems a safe change to make.