### PR TITLE
Fix a problem with effects not stopping.

### DIFF
--- a/Notchmeister/Notchmeister/NotchView.swift
+++ b/Notchmeister/Notchmeister/NotchView.swift
@@ -70,6 +70,7 @@ class NotchView: NSView {
 		//debugLog()
 		let point = notchLocation(with: windowPoint)
 		let underNotch = bounds.contains(point)
+        notchEffect?.mouseMoved(at: point, underNotch: underNotch)
 		notchEffect?.mouseExited(at: point, underNotch: underNotch)
 	}
 }

--- a/Notchmeister/Notchmeister/NotchView.swift
+++ b/Notchmeister/Notchmeister/NotchView.swift
@@ -69,7 +69,7 @@ class NotchView: NSView {
 	func mouseExited(windowPoint: CGPoint) {
 		//debugLog()
 		let point = notchLocation(with: windowPoint)
-		let underNotch = bounds.contains(point)
+        let underNotch = bounds.contains(point)
         notchEffect?.mouseMoved(at: point, underNotch: underNotch)
 		notchEffect?.mouseExited(at: point, underNotch: underNotch)
 	}

--- a/Notchmeister/Notchmeister/NotchView.swift
+++ b/Notchmeister/Notchmeister/NotchView.swift
@@ -69,8 +69,8 @@ class NotchView: NSView {
 	func mouseExited(windowPoint: CGPoint) {
 		//debugLog()
 		let point = notchLocation(with: windowPoint)
-        let underNotch = bounds.contains(point)
-        notchEffect?.mouseMoved(at: point, underNotch: underNotch)
+		let underNotch = bounds.contains(point)
+		notchEffect?.mouseMoved(at: point, underNotch: underNotch)
 		notchEffect?.mouseExited(at: point, underNotch: underNotch)
 	}
 }


### PR DESCRIPTION
With a multiple display setup, some effects would not stop when the mouse existed the notch. If a display is oriented above the notched display, the mouse cursor can move out the 'top' of the notch.

 Many of our effects stop rendering when the mouse has moved outside the notch or some distance from the notch. This works because the mouse tracking area extends beyond the the bounds of the notch to the sides and below the notch. In these scenarios we generate `mouseMoved()` calls when the cursor leaves the notch, but is still in that tracking area. In this case though, the mouse can exit the notch at the top, which means it leaves the notch and the tracking area in one update of mouse position. This results in no `mousedMoved()` call, but an immediate `mouseExited()` call.

Effects that expect to end their rendering on a `mouseMove()` that happens with `underNotch == false` would then fail to stop. We could make sure that each effect also stops rendering on `mouseExited()`, but that leaves the door open to repeat this problem because it is not enforced.

This fix adds an explicit call to` mouseMoved(at:underNotch:)` before the call to `mouseExited(at:point:)`. This ensures that any code in mouseMoved that switches on under the notch or not still gets a chance to run in the exit case.